### PR TITLE
Making HPC compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ samples.txt
 \.\.\\logerror*
 /GSA_parameters
 *.sh
+*.out
+*.err

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ samples.txt
 /GSA_env
 \.\.\\logerror*
 /GSA_parameters
+*.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@ contourpy==1.3.1
 cycler==0.12.1
 dill==0.3.9
 fonttools==4.54.1
-gamsapi==48.2.0
+gamsapi==47.6.0
 gamspy==1.1.0
-gamspy_base==48.2.0
+gamspy_base==47.6.0
 kiwisolver==1.4.7
 matplotlib==3.9.2
 multiprocess==0.70.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cycler==0.12.1
 dill==0.3.9
 fonttools==4.54.1
 gamsapi==47.6.0
-gamspy==1.1.0
+gamspy==1.0.3
 gamspy_base==47.6.0
 kiwisolver==1.4.7
 matplotlib==3.9.2


### PR DESCRIPTION
I added some HPC relevant files to the gitignore (.sh, .err and .out files) and changed the versions of gamspy and gamsapi in the requirements file according to the GAMS version on the HPC.